### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kturtle.json
+++ b/org.kde.kturtle.json
@@ -12,6 +12,9 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/share/doc"
+    ],
     "modules": [
         {
             "name": "kturtle",


### PR DESCRIPTION
The installed size reduced from 4.1 MB to 814 kB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.